### PR TITLE
Using WalletApp data model instead of Map<String, dynamic>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.3
+
+Breaking Changes:
+
+- Use `WalletApp` model instead of `Map<String, dynamic>` to manage supported wallets
+
 ## 1.0.2
 
 - Added prefix in SharedPrefences methods to avoid variable matches in the app.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ import 'package:darttonconnect/ton_connect.dart';
 
 Future<void> main() async {
   final connector = TonConnect('https://raw.githubusercontent.com/XaBbl4/pytonconnect/main/pytonconnect-manifest.json');
-  final List wallets = await connector.getWallets();
+  final List<WalletApp> wallets = await connector.getWallets();
   print('Wallets: $wallets');
 }
 ```

--- a/lib/models/wallet_app.dart
+++ b/lib/models/wallet_app.dart
@@ -1,0 +1,35 @@
+class WalletApp {
+  final String name;
+  final String bridgeUrl;
+  final String image;
+  final String? universalUrl;
+  final String aboutUrl;
+
+  const WalletApp({
+    required this.name,
+    required this.bridgeUrl,
+    required this.image,
+    required this.aboutUrl,
+    this.universalUrl,
+  });
+
+  factory WalletApp.fromMap(Map<String, dynamic> json) {
+   String bridgeUrl = json.containsKey('bridge_url') ?
+        json['bridge_url'].toString() :
+        (json.containsKey('bridge')
+            ? (json['bridge'] as List).firstWhere(
+                (bridge) => bridge['type'] == 'sse',
+                orElse: () => '')['url'].toString()
+            : '');
+
+    return WalletApp(
+      name: json['name'].toString(),
+      image: json['image'].toString(),
+      bridgeUrl: bridgeUrl,
+      aboutUrl: json['about_url'].toString(),
+      universalUrl: json.containsKey('universal_url')
+          ? json['universal_url'].toString()
+          : null,
+    );
+  }
+}

--- a/lib/provider/bridge_provider.dart
+++ b/lib/provider/bridge_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:darttonconnect/crypto/session_crypto.dart';
+import 'package:darttonconnect/models/wallet_app.dart';
 import 'package:darttonconnect/provider/bridge_gateway.dart';
 import 'package:darttonconnect/provider/bridge_session.dart';
 import 'package:darttonconnect/provider/provider.dart';
@@ -15,16 +16,16 @@ class BridgeProvider extends BaseProvider {
   static const String standartUniversalUrl = 'tc://';
 
   late IStorage _storage;
-  late Map<String, dynamic> _wallet;
+  WalletApp? _wallet;
 
   late BridgeSession _session;
   BridgeGateway? _gateway;
   late Map<String, Completer<Map<String, dynamic>>> _pendingRequests;
   late List<dynamic> _listeners;
 
-  BridgeProvider(IStorage storage, {Map<String, dynamic>? wallet}) {
+  BridgeProvider(IStorage storage, {WalletApp? wallet}) {
     _storage = storage;
-    _wallet = wallet ?? {};
+    _wallet = wallet;
 
     _session = BridgeSession();
     _gateway = null;
@@ -36,13 +37,9 @@ class BridgeProvider extends BaseProvider {
     _closeGateways();
     final sessionCrypto = SessionCrypto();
 
-    var bridgeUrl = '';
-    var universalUrl = BridgeProvider.standartUniversalUrl;
-
-    bridgeUrl = _wallet['bridge_url'];
-    if (_wallet.containsKey('universal_url')) {
-      universalUrl = _wallet['universal_url'];
-    }
+    String bridgeUrl = _wallet?.bridgeUrl ?? '';
+    String universalUrl = _wallet?.universalUrl ?? BridgeProvider.standartUniversalUrl;
+    
     _gateway = BridgeGateway(
       _storage,
       bridgeUrl,

--- a/lib/ton_connect.dart
+++ b/lib/ton_connect.dart
@@ -1,5 +1,6 @@
 import 'package:darttonconnect/exceptions.dart';
 import 'package:darttonconnect/logger.dart';
+import 'package:darttonconnect/models/wallet_app.dart';
 import 'package:darttonconnect/parsers/connect_event.dart';
 import 'package:darttonconnect/parsers/send_transaction.dart';
 import 'package:darttonconnect/provider/bridge_provider.dart';
@@ -40,7 +41,7 @@ class TonConnect {
   }
 
   /// Return available wallets list.
-  Future<List<Map<String, dynamic>>> getWallets() async {
+  Future<List<WalletApp>> getWallets() async {
     return await _walletsList.getWallets();
   }
 
@@ -67,7 +68,7 @@ class TonConnect {
 
   /// Generates universal link for an external wallet and subscribes to the wallet's bridge,
   /// or sends connect request to the injected wallet.
-  Future<String> connect(dynamic wallet, [dynamic request]) async {
+  Future<String> connect(WalletApp wallet, [dynamic request]) async {
     if (connected) {
       throw WalletAlreadyConnectedError(null);
     }
@@ -181,7 +182,7 @@ class TonConnect {
     }
   }
 
-  BridgeProvider _createProvider(Map<String, dynamic> wallet) {
+  BridgeProvider _createProvider(WalletApp wallet) {
     BridgeProvider provider = BridgeProvider(storage, wallet: wallet);
     provider.listen(_walletEventsListener);
     return provider;

--- a/lib/wallets_list_manager.dart
+++ b/lib/wallets_list_manager.dart
@@ -1,29 +1,21 @@
 import 'dart:convert';
 import 'package:darttonconnect/exceptions.dart';
+import 'package:darttonconnect/models/wallet_app.dart';
 import 'package:http/http.dart' as http;
 
 const fallbackWalletsList = [
-  {
-    "name": "Tonkeeper",
-    "image": "https://tonkeeper.com/assets/tonconnect-icon.png",
-    "tondns": "tonkeeper.ton",
-    "about_url": "https://tonkeeper.com",
-    "universal_url": "https://app.tonkeeper.com/ton-connect",
-    "bridge": [
-      {"type": "sse", "url": "https://bridge.tonapi.io/bridge"},
-      {"type": "js", "key": "tonkeeper"}
-    ]
-  },
-  {
-    "name": "Tonhub",
-    "image": "https://tonhub.com/tonconnect_logo.png",
-    "about_url": "https://tonhub.com",
-    "universal_url": "https://tonhub.com/ton-connect",
-    "bridge": [
-      {"type": "js", "key": "tonhub"},
-      {"type": "sse", "url": "https://connect.tonhubapi.com/tonconnect"}
-    ]
-  }
+  WalletApp(
+      name: 'Tonkeeper',
+      bridgeUrl: 'https://bridge.tonapi.io/bridge',
+      image: 'https://tonkeeper.com/assets/tonconnect-icon.png',
+      aboutUrl: 'https://tonkeeper.com',
+      universalUrl: 'https://app.tonkeeper.com/ton-connect'),
+  WalletApp(
+      name: 'Tonhub',
+      bridgeUrl: 'https://connect.tonhubapi.com/tonconnect',
+      image: 'https://tonhub.com/tonconnect_logo.png',
+      aboutUrl: 'https://tonhub.com',
+      universalUrl: 'https://tonhub.com/ton-connect')
 ];
 
 class WalletsListManager {
@@ -32,7 +24,7 @@ class WalletsListManager {
   final int? _cacheTtl;
 
   dynamic _dynamicWalletsListCache;
-  List<Map<String, dynamic>> walletsListCache = [];
+  List<WalletApp> walletsListCache = [];
   int? _walletsListCacheCreationTimestamp;
 
   WalletsListManager({String? walletsListSource, int? cacheTtl})
@@ -42,7 +34,7 @@ class WalletsListManager {
     }
   }
 
-  Future<List<Map<String, dynamic>>> getWallets() async {
+  Future<List<WalletApp>> getWallets() async {
     final currentTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     if (_cacheTtl != null &&
         _walletsListCacheCreationTimestamp != null &&
@@ -51,13 +43,14 @@ class WalletsListManager {
     }
 
     if (_dynamicWalletsListCache == null) {
-      List<Map<String, dynamic>> walletsList = [];
+      List<WalletApp> walletsList = [];
       try {
         final response = await http.get(Uri.parse(_walletsListSource));
         if (response.statusCode == 200) {
           final responseBody = jsonDecode(response.body);
           if (responseBody is List) {
-            walletsList = responseBody.cast<Map<String, dynamic>>();
+            walletsList =
+                responseBody.map((e) => WalletApp.fromMap(e)).toList();
           } else {
             throw FetchWalletsError(
                 'Wrong wallets list format, wallets list must be an array.');
@@ -71,55 +64,12 @@ class WalletsListManager {
 
       walletsListCache = [];
       for (final wallet in walletsList) {
-        final supportedWallet = _getSupportedWalletConfig(wallet);
-        if (supportedWallet != null) {
-          walletsListCache.add(supportedWallet);
-        }
+        walletsListCache.add(wallet);
       }
 
       _walletsListCacheCreationTimestamp = currentTimestamp;
     }
 
     return walletsListCache;
-  }
-
-  Map<String, dynamic>? _getSupportedWalletConfig(dynamic wallet) {
-    if (wallet is! Map<String, dynamic>) {
-      return null;
-    }
-
-    final containsName = wallet.containsKey('name');
-    final containsImage = wallet.containsKey('image');
-    final containsAbout = wallet.containsKey('about_url');
-
-    if (!containsName || !containsImage || !containsAbout) {
-      return null;
-    }
-
-    if (!wallet.containsKey('bridge') ||
-        wallet['bridge'] is! List ||
-        (wallet['bridge'] as List).isEmpty) {
-      return null;
-    }
-
-    final bridgeList = wallet['bridge'] as List;
-    final sseBridge = bridgeList.firstWhere((bridge) => bridge['type'] == 'sse',
-        orElse: () => null);
-    if (sseBridge == null || !sseBridge.containsKey('url')) {
-      return null;
-    }
-
-    final walletConfig = <String, dynamic>{
-      'name': wallet['name'],
-      'image': wallet['image'],
-      'about_url': wallet['about_url'],
-      'bridge_url': sseBridge['url'],
-    };
-
-    if (wallet.containsKey('universal_url')) {
-      walletConfig['universal_url'] = wallet['universal_url'];
-    }
-
-    return walletConfig;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: darttonconnect
 description: Dart SDK for TON Connect. Use it to connect your app to TON wallets via TonConnect protocol.
-version: 1.0.2+1
+version: 1.0.3
 homepage: https://github.com/romanovichim/dartTonconnect
 
 environment:


### PR DESCRIPTION
Also Solves #1 

Breaking change PR.

Making it possible to access different properties of Wallets like image, name, ... through a model named `WalletApp`.
This PR will force user to use WalletApp instead of that Map to reach the supported wallets attributes and etc.